### PR TITLE
Fixed problem with inconsistent image sizes on publications page 

### DIFF
--- a/src/styles/PublicationsPage.module.less
+++ b/src/styles/PublicationsPage.module.less
@@ -18,7 +18,7 @@
       border-radius: 12px;
       box-shadow: 3px 6px 20px 5px #c9c9c9;
       height: 320px;
-      max-width: 350px;
+      width: 350px;
       object-fit: cover;
     }
   }


### PR DESCRIPTION
This fixes the bug where images on the publications page appeared to be different sizes. Images are now all the same size.