### PR TITLE
Team page text overlap fix

### DIFF
--- a/src/pages/OurTeamPage.tsx
+++ b/src/pages/OurTeamPage.tsx
@@ -13,7 +13,7 @@ import styles from '../styles/OurTeamPage.module.less';
 const MemberCard: React.FC<MemberCardProps> = (props) => {
   return (
     <div className={styles.ourteampage_member}>
-      <Avatar className={styles.ourteampage_avatar} size={150} src={props.imgSrc} />
+      <Avatar className={styles.ourteampage_avatar} src={props.imgSrc} />
       <div className={styles.ourteampage_text}>
         <Typography.Title level={3}>{props.title}</Typography.Title>
         <Typography.Text>{props.subtitle}</Typography.Text>

--- a/src/styles/ContentLayout.module.less
+++ b/src/styles/ContentLayout.module.less
@@ -2,6 +2,9 @@
 
 .contentlayoutcontainer {
   width: 100%;
+  @media screen and (max-width: 1000px) {
+    padding: calc(@navbar-height + 3rem) 3%;
+}
   padding: calc(@navbar-height + 3rem) 9%;
 }
 

--- a/src/styles/OurTeamPage.module.less
+++ b/src/styles/OurTeamPage.module.less
@@ -23,12 +23,15 @@
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
+  padding: 0 1rem;
 }
 
 .ourteampage_avatar {
   box-shadow: 4px 4px 28px 0 rgba(0, 0, 0, 0.12);
   margin-right: 8%;
   flex-shrink: 0;
+  min-height: 100px;
+  min-width: 100px;
 }
 
 .ourteampage_text {
@@ -47,7 +50,7 @@
 
 .teamcardsgrid {
   display: grid;
-  gap: @big-size @extra-large-size;
+  gap: @big-size 0;
   justify-content: stretch;
   align-items: stretch;
   grid-auto-columns: 20%;

--- a/src/styles/themes.less
+++ b/src/styles/themes.less
@@ -1,5 +1,5 @@
 @primary-color: #0b688a;
-@mobile-cutoff: 800px;
+@mobile-cutoff: 900px;
 //issue found:
 /*when code is compiled, less => css; therefore, variable can't be changed during runtime,
 so instead, @font-base-size is changed to 1rem and is changed according to font-size in html element
@@ -11,12 +11,6 @@ html {
 body {
   font-family: 'Open Sans', sans-serif;
   font-weight: 400;
-}
-
-@media screen and (max-width: 1000px) {
-  html {
-    font-size: 14px;
-  }
 }
 
 @media screen and (max-width: @mobile-cutoff) {


### PR DESCRIPTION
Fixes bug with both text-overlap on the media page as well as text getting cut off on the right side of the window as the window is resized.