### PR TITLE
Update faq line spacing to single space

### DIFF
--- a/src/styles/FAQ.less
+++ b/src/styles/FAQ.less
@@ -2,7 +2,7 @@
 
 .faq-container {
     .faq-collapse-content  > * {
-        line-height: 2.6rem;
+        line-height: 1.6rem;
     }
     .faq-collapse-panel-0 {
         border-top: 1px solid #d9d9d9;


### PR DESCRIPTION
Updated the faq container to make all text single spaced. This fixes the bug where the text goes to double space when a link is incorporated.